### PR TITLE
Mention that the lint jar has to be executable

### DIFF
--- a/schemacrawler-site/src/site/markdown/lint.md
+++ b/schemacrawler-site/src/site/markdown/lint.md
@@ -168,5 +168,5 @@ The main distribution has example code. In order to add your own lint checks,
 - Package your code in a jar file, and make sure that the jar has a text file 
   called `META-INF\services\schemacrawler.tools.lint.Linter` , 
   which contains the classnames of your linter classes 
-- Drop your jar file in the SchemaCrawler lib directory, and create a 
+- Drop your jar file in the SchemaCrawler lib directory (and **make sure it is executable or it will be silently skipped**), and create a 
   SchemaCrawler Lint report


### PR DESCRIPTION
Mention that the lint jar has to be executable on 'nix like platforms. If you use the debian installer, you typically has to copy and perform the proper grant, for example

` sudo chmod  a+x /opt/schemacrawler-14.02.01/lib/schemacrawler-additionnallints-1.1-SNAPSHOT.jar`