### PR TITLE
[fix #7] - added support for optionally retrieving reserved words

### DIFF
--- a/schemacrawler-api/src/main/java/schemacrawler/schemacrawler/DatabaseSpecificOverrideOptions.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/schemacrawler/DatabaseSpecificOverrideOptions.java
@@ -11,21 +11,24 @@ public final class DatabaseSpecificOverrideOptions
 
   private final Boolean supportsSchemas;
   private final Boolean supportsCatalogs;
+  private final Boolean supportsReservedWords;
   private final String identifierQuoteString;
   private final InformationSchemaViews informationSchemaViews;
 
   public DatabaseSpecificOverrideOptions()
   {
-    this(null, null, null, null);
+    this(null, null, null, null, null);
   }
 
   protected DatabaseSpecificOverrideOptions(final Boolean supportsSchemas,
                                             final Boolean supportsCatalogs,
+                                            final Boolean supportsReservedWords,
                                             final String identifierQuoteString,
                                             final InformationSchemaViews informationSchemaViews)
   {
     this.supportsSchemas = supportsSchemas;
     this.supportsCatalogs = supportsCatalogs;
+    this.supportsReservedWords = supportsReservedWords;
     this.identifierQuoteString = identifierQuoteString;
     this.informationSchemaViews = informationSchemaViews == null? new InformationSchemaViews()
                                                                 : informationSchemaViews;
@@ -60,6 +63,11 @@ public final class DatabaseSpecificOverrideOptions
     return supportsSchemas != null;
   }
 
+  public boolean hasOverrideForSupportsReservedWords()
+  {
+    return supportsReservedWords != null;
+  }
+
   public boolean isSupportsCatalogs()
   {
     if (supportsCatalogs == null)
@@ -76,6 +84,15 @@ public final class DatabaseSpecificOverrideOptions
       return true;
     }
     return supportsSchemas;
+  }
+
+  public boolean isSupportsReservedWords()
+  {
+    if (supportsReservedWords == null)
+    {
+      return true;
+    }
+    return supportsReservedWords;
   }
 
 }

--- a/schemacrawler-api/src/main/java/schemacrawler/schemacrawler/DatabaseSpecificOverrideOptionsBuilder.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/schemacrawler/DatabaseSpecificOverrideOptionsBuilder.java
@@ -9,6 +9,7 @@ public class DatabaseSpecificOverrideOptionsBuilder
 
   private Boolean supportsSchemas;
   private Boolean supportsCatalogs;
+  private Boolean supportsReservedWords;
   private String identifierQuoteString;
   private final InformationSchemaViewsBuilder informationSchemaViewsBuilder;
 
@@ -77,6 +78,26 @@ public class DatabaseSpecificOverrideOptionsBuilder
 
   /**
    * Overrides the JDBC driver provided information about whether the database
+   * supports reserved words.
+   */
+  public DatabaseSpecificOverrideOptionsBuilder doesNotSupportsReservedWords()
+  {
+    supportsReservedWords = Boolean.FALSE;
+    return this;
+  }
+
+  /**
+   * Overrides the JDBC driver provided information about whether the database
+   * supports reserved words.
+   */
+  public DatabaseSpecificOverrideOptionsBuilder supportsReservedWords()
+  {
+    supportsReservedWords = Boolean.TRUE;
+    return this;
+  }
+
+  /**
+   * Overrides the JDBC driver provided information about whether the database
    * supports schema.
    */
   public DatabaseSpecificOverrideOptionsBuilder supportsSchemas()
@@ -96,6 +117,7 @@ public class DatabaseSpecificOverrideOptionsBuilder
   {
     return new DatabaseSpecificOverrideOptions(supportsSchemas,
                                                supportsCatalogs,
+                                               supportsReservedWords,
                                                identifierQuoteString,
                                                informationSchemaViewsBuilder
                                                  .toOptions());
@@ -121,6 +143,12 @@ public class DatabaseSpecificOverrideOptionsBuilder
   public DatabaseSpecificOverrideOptionsBuilder withoutSupportsSchemas()
   {
     supportsSchemas = null;
+    return this;
+  }
+
+  public DatabaseSpecificOverrideOptionsBuilder withoutSupportsReservedWords()
+  {
+    supportsReservedWords = null;
     return this;
   }
 


### PR DESCRIPTION
This allows us to work around the permission issue where the database did not allow us to retrieve the reserved words, but we are still able fetch the schema meta data.