### PR TITLE
Adding section for the rpm (Fedora,...) package

### DIFF
--- a/schemacrawler-site/src/site/markdown/ecosystem.md
+++ b/schemacrawler-site/src/site/markdown/ecosystem.md
@@ -30,3 +30,9 @@ Adrien Sales <Adrien.Sales at GMail>.
 
 <a href="https://github.com/adriens/schemacrawler-deb/releases/latest">
 <img src="https://img.shields.io/badge/download-deb-7B2A90.svg" /></a>
+
+### RPM SchemaCrawler package
+The [rpm schemacrawler package](https://github.com/adriens/schemacrawler-rpm) is maintained by
+Adrien Sales <Adrien.Sales at GMail>.
+
+Latest RPM can be downloaded from the <a href="https://github.com/adriens/schemacrawler-rpm/releases/latest">release page</a>


### PR DESCRIPTION
Adding section for the rpm (Fedora, CentOS, Opensuse, ...) package.

RPM blason could be added too like you did it for the debian one as it looks really great. The rpm package is also continously built.