### PR TITLE
Fix column data type mapping for Oracle DBMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 /schemacrawler-examplecode/derby.log
+
+*.iml
+.idea

--- a/schemacrawler-api/src/main/java/schemacrawler/crawl/AbstractRetriever.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/crawl/AbstractRetriever.java
@@ -190,8 +190,8 @@ abstract class AbstractRetriever
                                                      final String mappedClassName)
   {
     MutableColumnDataType columnDataType = catalog
-      .lookupColumnDataType(schema, databaseSpecificTypeName).orElse(catalog
-        .lookupSystemColumnDataType(databaseSpecificTypeName).orElse(null));
+      .lookupColumnDataType(schema, javaSqlTypeInt, databaseSpecificTypeName).orElse(catalog
+        .lookupSystemColumnDataType(javaSqlTypeInt, databaseSpecificTypeName).orElse(null));
     // Create new data type, if needed
     if (columnDataType == null)
     {

--- a/schemacrawler-api/src/main/java/schemacrawler/crawl/ColumnDataTypes.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/crawl/ColumnDataTypes.java
@@ -29,9 +29,10 @@ package schemacrawler.crawl;
 
 
 import schemacrawler.schema.NamedObject;
-import schemacrawler.schema.Schema;
 import schemacrawler.schema.SchemaReference;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 class ColumnDataTypes
@@ -56,6 +57,18 @@ class ColumnDataTypes
       }
     }
     return columnDataType;
+  }
+
+  List<MutableColumnDataType> lookupColumnDataTypesByName(final String name) {
+    final SchemaReference systemSchema = new SchemaReference();
+    List<MutableColumnDataType> types = new ArrayList<>();
+    for (final MutableColumnDataType currentColumnDataType : this) {
+      if (name.equals(currentColumnDataType.getDatabaseSpecificTypeName())
+              && systemSchema.equals(currentColumnDataType.getSchema())) {
+        types.add(currentColumnDataType);
+      }
+    }
+    return types;
   }
 
   Optional<MutableColumnDataType> lookup(final NamedObject namedObject, final String name, final int sqlType) {

--- a/schemacrawler-api/src/main/java/schemacrawler/crawl/ColumnDataTypes.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/crawl/ColumnDataTypes.java
@@ -28,7 +28,11 @@ http://www.gnu.org/licenses/
 package schemacrawler.crawl;
 
 
+import schemacrawler.schema.NamedObject;
+import schemacrawler.schema.Schema;
 import schemacrawler.schema.SchemaReference;
+
+import java.util.Optional;
 
 class ColumnDataTypes
   extends NamedObjectList<MutableColumnDataType>
@@ -52,6 +56,10 @@ class ColumnDataTypes
       }
     }
     return columnDataType;
+  }
+
+  Optional<MutableColumnDataType> lookup(final NamedObject namedObject, final String name, final int sqlType) {
+    return this.lookup(namedObject, name + "." + sqlType);
   }
 
 }

--- a/schemacrawler-api/src/main/java/schemacrawler/crawl/MutableCatalog.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/crawl/MutableCatalog.java
@@ -294,9 +294,10 @@ final class MutableCatalog
    */
   @Override
   public Optional<MutableColumnDataType> lookupColumnDataType(final Schema schema,
+                                                              final int sqlTypeInt,
                                                               final String name)
   {
-    return columnDataTypes.lookup(schema, name);
+    return columnDataTypes.lookup(schema, name, sqlTypeInt);
   }
 
   /**
@@ -350,12 +351,12 @@ final class MutableCatalog
   /**
    * {@inheritDoc}
    *
-   * @see schemacrawler.schema.Catalog#lookupSystemColumnDataType(java.lang.String)
+   * @see schemacrawler.schema.Catalog#lookupSystemColumnDataType(int, java.lang.String)
    */
   @Override
-  public Optional<MutableColumnDataType> lookupSystemColumnDataType(final String name)
+  public Optional<MutableColumnDataType> lookupSystemColumnDataType(final int sqlTypeInt, final String name)
   {
-    return lookupColumnDataType(new SchemaReference(), name);
+    return lookupColumnDataType(new SchemaReference(), sqlTypeInt, name);
   }
 
   /**

--- a/schemacrawler-api/src/main/java/schemacrawler/crawl/MutableColumnDataType.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/crawl/MutableColumnDataType.java
@@ -418,4 +418,10 @@ final class MutableColumnDataType
     this.userDefined = userDefined;
   }
 
+  @Override
+  public String getLookupKey() {
+    // Change the lookup key so that it includes the java sql type. This allows for the same database specific type name to be mapped to multiple
+    // ColumnDataTypes. This is required for Oracle NUMBER, which can be mapped to multiple types, ranging from BIT/Boolean to BigDecimal
+    return super.getLookupKey() + "." + this.getJavaSqlType().getJavaSqlType();
+  }
 }

--- a/schemacrawler-api/src/main/java/schemacrawler/schema/Catalog.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/schema/Catalog.java
@@ -134,13 +134,16 @@ public interface Catalog
   Collection<Table> getTables(Schema schema);
 
   /**
-   * Gets the column data types defined in the schema, by name.
+   * Gets the column data types defined in the schema, by name and sql type number.
    *
    * @param name
    *        Name
+   * @param sqlTypeInt
+   *        The sql type int from the RDBMS
    * @return Column data types
    */
   Optional<? extends ColumnDataType> lookupColumnDataType(Schema schema,
+                                                          int sqlTypeInt,
                                                           String name);
 
   /**
@@ -180,13 +183,15 @@ public interface Catalog
   Optional<? extends Synonym> lookupSynonym(Schema schema, String name);
 
   /**
-   * Gets the column data types defined by the RDBMS system, by name.
+   * Gets the column data types defined by the RDBMS system, by name and sql type number.
    *
    * @param name
    *        Column data type name
+   * @param sqlTypeInt
+   *        Column data type sql type number
    * @return Column data type
    */
-  Optional<? extends ColumnDataType> lookupSystemColumnDataType(String name);
+  Optional<? extends ColumnDataType> lookupSystemColumnDataType(int sqlTypeInt, String name);
 
   /**
    * Gets a table by unqualified name.

--- a/schemacrawler-api/src/main/java/schemacrawler/schemacrawler/BaseCatalogDecorator.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/schemacrawler/BaseCatalogDecorator.java
@@ -223,9 +223,10 @@ public abstract class BaseCatalogDecorator
 
   @Override
   public Optional<? extends ColumnDataType> lookupColumnDataType(final Schema schema,
+                                                                 final int sqlTypeInt,
                                                                  final String name)
   {
-    return catalog.lookupColumnDataType(schema, name);
+    return catalog.lookupColumnDataType(schema, sqlTypeInt, name);
   }
 
   @Override
@@ -263,9 +264,9 @@ public abstract class BaseCatalogDecorator
   }
 
   @Override
-  public Optional<? extends ColumnDataType> lookupSystemColumnDataType(final String name)
+  public Optional<? extends ColumnDataType> lookupSystemColumnDataType(final int sqlTypeInt, final String name)
   {
-    return catalog.lookupSystemColumnDataType(name);
+    return catalog.lookupSystemColumnDataType(sqlTypeInt, name);
   }
 
   @Override


### PR DESCRIPTION
This fixes a bug I encountered while using SchemaCrawler with an Oracle 11g Express Edition (11.2.0.2.0) and the ojdbc6 driver (`com.oracle:ojdbc6:11.2.0.3`).

The database includes many tables with their id column specified as `NUMBER(19)`.
The JBDC driver provides many JavaSQLTypes for the type `NUMBER`, each with an unique Integer identifying them. 

The `AbstractRetriever` on the other hand, identifies the `ColumnDataType` only by the database type name, here correctly reported as `NUMBER` by the JDBC Driver. When registering the datatypes for the first time, the first `NUMBER` that gets passed to `lookupOrCreateColumnDataType` has the Java SQL Type `BIT`, resulting each id column having `java.lang.Boolean` instead of `java.math.BigDecimal` as the datatype provided by SchemaCrawler. And because `Column.getColumnDataType().getJavaSqlType()` returns the wrong SQL type as well, there is no way to extract the correct datatype afterwards.

This pull request fixes that problem by changing the lookup key for the  `MutableColumnDataType` to include the java sql type integer. I also added a new convenience method for finding all `MutableColumnDataType`s with the same SQL type name.

With these changes everything compiles just fine and the tests for `schemacrawler-api` run without problems. As these changes are only internal and do not change the exposed API there should be no problem with backwards compatibility. 