### PR TITLE
Added fallback lookup for optionalTable if catalog is null

### DIFF
--- a/schemacrawler-api/src/main/java/schemacrawler/crawl/TableColumnRetriever.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/crawl/TableColumnRetriever.java
@@ -182,11 +182,16 @@ final class TableColumnRetriever
                                 tableName,
                                 columnName));
 
-    final Optional<MutableTable> optionalTable = allTables
+    Optional<MutableTable> optionalTable = allTables
       .lookup(new SchemaReference(columnCatalogName, schemaName), tableName);
     if (!optionalTable.isPresent())
     {
-      return null;
+      // try to lookup a table without columnCatalogName
+      optionalTable = allTables
+              .lookup(new SchemaReference(null, schemaName), tableName);
+      if(!optionalTable.isPresent()){
+        return null;
+      }
     }
 
     final MutableTable table = optionalTable.get();


### PR DESCRIPTION
Added a fallback lookup of table in the case of the catalogname being null.
Using JTOpen and connecting to the AS400, this failed. The metadata
of the schema returned a null value for the catalog (allowed according to
the spec), but the column metadata returned a catalog.
Schemacrawler couln't find a candidate for the table to add the column to
because allTables didn't contain the catalogname in the lookup key.