### PR TITLE
Fix command used in sample usage

### DIFF
--- a/schemacrawler-docker/README.md
+++ b/schemacrawler-docker/README.md
@@ -27,7 +27,7 @@ Then, run SchemaCrawler from the command-line within the container, like this
 ```
 ./schemacrawler.sh \
 -server=sqlite -user= -password= -database=sc.db \
--infolevel=maximum -routines= -command=graph \
+-infolevel=maximum -routines= -command=schema \
 -outputfile=/share/sc_db.png
 ```
 The image exports a volume called `/share`, and you can map it to your local directory. 


### PR DESCRIPTION
When using the `graph` command of the given sample, no PNG output file is created. I ran that sample again, adding the -loglevel=ALL
 flag, getting this hint: `INFO: Output format <png> not supported for command <graph>`. If you instead use the `schema` command, the PNG output file is successfully generated.