### PR TITLE
schemacrawler-api is available without third party classes in the same jar

### DIFF
--- a/schemacrawler-api/pom.xml
+++ b/schemacrawler-api/pom.xml
@@ -33,13 +33,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/schemacrawler-archetype-maven-project/src/main/resources/archetype-resources/pom.xml
+++ b/schemacrawler-archetype-maven-project/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
     </dependency>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${schemacrawler.version}</version>
     </dependency>
   </dependencies>

--- a/schemacrawler-archetype-plugin-command/src/main/resources/archetype-resources/pom.xml
+++ b/schemacrawler-archetype-plugin-command/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
     </dependency>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${schemacrawler.version}</version>
     </dependency>
   </dependencies>

--- a/schemacrawler-archetype-plugin-dbconnector/src/main/resources/archetype-resources/pom.xml
+++ b/schemacrawler-archetype-plugin-dbconnector/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,7 @@
     </dependency>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${schemacrawler.version}</version>
     </dependency>
   </dependencies>

--- a/schemacrawler-db2/pom.xml
+++ b/schemacrawler-db2/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/schemacrawler-dbtest/pom.xml
+++ b/schemacrawler-dbtest/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-examplecode/pom.xml
+++ b/schemacrawler-examplecode/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-hsqldb/pom.xml
+++ b/schemacrawler-hsqldb/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-integrations/pom.xml
+++ b/schemacrawler-integrations/pom.xml
@@ -101,15 +101,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/schemacrawler-lint/pom.xml
+++ b/schemacrawler-lint/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-mysql/pom.xml
+++ b/schemacrawler-mysql/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-offline/pom.xml
+++ b/schemacrawler-offline/pom.xml
@@ -14,7 +14,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-oracle/pom.xml
+++ b/schemacrawler-oracle/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/schemacrawler-postgresql/pom.xml
+++ b/schemacrawler-postgresql/pom.xml
@@ -14,7 +14,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-sqlite/pom.xml
+++ b/schemacrawler-sqlite/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/schemacrawler-sqlserver/pom.xml
+++ b/schemacrawler-sqlserver/pom.xml
@@ -14,7 +14,7 @@
   <dependencies>
     <dependency>
       <groupId>us.fatehi</groupId>
-      <artifactId>schemacrawler</artifactId>
+      <artifactId>schemacrawler-integrations</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Use case: I'd like to use schemacrawler via Java API in my project. Today, this means pulling in the "schemacrawler" artifact, and the DBMS-specific modules like "schemacrawler-db2" depend on "schemacrawler"

However, "schemacrawler" is published as a jar that includes the third party dependency classes. Thus, I can't include other versions of jars that schemacrawler had already included as there would be a classpath conflict. So ideally I'd want to access the schemacrawler jar without the third-party class included (and instead resolved as third party dependencies via maven), but at the same time existing clients should get the same "schemacrawler" jar as before.

The "schemacrawler" module itself simply pulls in the dependencies from schemacrawler-integrations and schemacrawler-api; those modules are not currently published to maven

So my proposal is as follows:
* The schemacrawler-api and schemacrawler-integrations modules should be published to maven; so I removed the "maven-deploy-plugin" setting to skip deploys
* The DBMS-specific modules like "schemacrawler-db2" now depend on schemacrawler-integrations, to keep compatibility for those modules as before.
* schemacrawler module remains the same, exposing the same jar
* As a client java user, I will now depend on schemacrawler-api or schemacrawler-integrations

Let me know what you think. This is a nice-to-have for me, but not a must-have

Another change that I think would be ideal is for the DBMS-specific modules like "schemacrawler-db2" to only depend on schemacrawler-api, as that would be the minimal API for the DBMS-specific items. If someone wants to pull in schemacrawler-integrations as an add-on, they still can. This is not a primary request of mine as it would hurt backwards-compatibility, so I'll defer to your opinion here
